### PR TITLE
Removed ngfilesort on build:compile

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -220,7 +220,6 @@ gulp.task('build:compile', ['clean:dist'], function()
 
 	//concat and compile all the js files
 	var jsfilesStream = gulp.src(all_js_files)
-		.pipe(ngfilesort())
 		.pipe(concat('app.js'))
 		.pipe(uglify())
 		.pipe(gulp.dest(buildConfig.js_dist_dir));


### PR DESCRIPTION
Angular files are already sorted in the build task.
